### PR TITLE
Allow tests superuser access to the database

### DIFF
--- a/lib/Test/PgMonger.pm
+++ b/lib/Test/PgMonger.pm
@@ -106,7 +106,7 @@ sub create_database ($self) {
 
   my $name = join q{_}, $self->basename, @hunks;
 
-  $self->master_dbh->do("CREATE USER $name WITH PASSWORD '$name'");
+  $self->master_dbh->do("CREATE USER $name WITH PASSWORD '$name' SUPERUSER");
 
   $self->master_dbh->do("CREATE DATABASE $name WITH OWNER $name");
 


### PR DESCRIPTION
That way if they require creating extensions and what not during
deploy, they can.